### PR TITLE
refactor: simplify component imports by exporting to global-component…

### DIFF
--- a/src/lib/blocks/landing-page/Hero.svelte
+++ b/src/lib/blocks/landing-page/Hero.svelte
@@ -1,4 +1,8 @@
-<section class="text-center min-h-screen flex items-center justify-center">
+<script lang="ts">
+	import { Button, Avatar } from '$lib/global-components';
+</script>
+
+<section class="flex items-center justify-center min-h-screen text-center">
 	<div
 		class="mx-auto"
 		style="
@@ -17,6 +21,11 @@
 			Things is the award-winning personal task manager that helps you plan your day, manage your
 			projects, and make real progress toward your goals.
 		</p>
-		<button class="bg-white text-blue-500 font-semibold py-2 px-4 rounded">Get Started</button>
+		<button class="px-4 py-2 font-semibold text-blue-500 bg-white rounded">Get Started</button>
+		<Button>ShadCN</Button>
+		<Avatar.Root>
+			<Avatar.Image src="https://github.com/shadcn.png" alt="@shadcn" />
+			<Avatar.Fallback>CN</Avatar.Fallback>
+		</Avatar.Root>
 	</div>
 </section>

--- a/src/lib/components/ui/avatar/avatar-fallback.svelte
+++ b/src/lib/components/ui/avatar/avatar-fallback.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { Avatar as AvatarPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = AvatarPrimitive.FallbackProps;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<AvatarPrimitive.Fallback
+	class={cn("bg-muted flex h-full w-full items-center justify-center rounded-full", className)}
+	{...$$restProps}
+>
+	<slot />
+</AvatarPrimitive.Fallback>

--- a/src/lib/components/ui/avatar/avatar-image.svelte
+++ b/src/lib/components/ui/avatar/avatar-image.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { Avatar as AvatarPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = AvatarPrimitive.ImageProps;
+
+	let className: $$Props["class"] = undefined;
+	export let src: $$Props["src"] = undefined;
+	export let alt: $$Props["alt"] = undefined;
+	export { className as class };
+</script>
+
+<AvatarPrimitive.Image
+	{src}
+	{alt}
+	class={cn("aspect-square h-full w-full", className)}
+	{...$$restProps}
+/>

--- a/src/lib/components/ui/avatar/avatar.svelte
+++ b/src/lib/components/ui/avatar/avatar.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { Avatar as AvatarPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = AvatarPrimitive.Props;
+
+	let className: $$Props["class"] = undefined;
+	export let delayMs: $$Props["delayMs"] = undefined;
+	export { className as class };
+</script>
+
+<AvatarPrimitive.Root
+	{delayMs}
+	class={cn("relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full", className)}
+	{...$$restProps}
+>
+	<slot />
+</AvatarPrimitive.Root>

--- a/src/lib/components/ui/avatar/index.ts
+++ b/src/lib/components/ui/avatar/index.ts
@@ -1,0 +1,13 @@
+import Root from "./avatar.svelte";
+import Image from "./avatar-image.svelte";
+import Fallback from "./avatar-fallback.svelte";
+
+export {
+	Root,
+	Image,
+	Fallback,
+	//
+	Root as Avatar,
+	Image as AvatarImage,
+	Fallback as AvatarFallback,
+};

--- a/src/lib/global-components.ts
+++ b/src/lib/global-components.ts
@@ -1,0 +1,5 @@
+// src/lib/global-components.ts
+import { Button } from '$lib/components/ui/button';
+import * as Avatar from '$lib/components/ui/avatar';
+
+export { Button, Avatar };


### PR DESCRIPTION
…s.ts

While autoimport with third-party plugins did not work for components with multiple files, simplified the import process by exporting components into a 'global-components.ts' file. Now, components can be imported in a single line, e.g., 'import { Button, Avatar } from '/global-components';'.